### PR TITLE
Add request filters to meta

### DIFF
--- a/thumbor/engines/json_engine.py
+++ b/thumbor/engines/json_engine.py
@@ -131,6 +131,8 @@ class JSONEngine(BaseEngine):
             filter_params = fltr[1]
             if filter_name == "fill":
                 self.request_filters["fill"] = filters["fill"].get_color(self, filter_params)
+            elif filter_name == "rotate":
+                self.request_filters["rotate"] = filter_params if int(filter_params) %90 == 0 else "0"
 
             else:
                 self.request_filters[filter_name] = filter_params

--- a/thumbor/engines/pil.py
+++ b/thumbor/engines/pil.py
@@ -371,7 +371,7 @@ class Engine(BaseEngine):
     def get_image_mode(self):
         return self.image.mode
 
-    def image_data_as_rgb(self, update_image=True):
+    def image_data_as_rgb(self, update_image=True, as_bytes=True):
         converted_image = self.image
 
         if converted_image.mode not in ["RGB", "RGBA"]:
@@ -385,6 +385,9 @@ class Engine(BaseEngine):
 
         if update_image:
             self.image = converted_image
+
+        if not as_bytes:
+            return converted_image.mode, converted_image
 
         return converted_image.mode, converted_image.tobytes()
 

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -11,8 +11,6 @@
 from thumbor.ext.filters import _fill
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.filters.blur import apply_blur
-from PIL import Image
-import io
 
 
 class Filter(BaseFilter):
@@ -26,9 +24,8 @@ class Filter(BaseFilter):
         )
 
     def get_first_pixel(self):
-        mode, data = self.engine.image_data_as_rgb()
-        image = Image.frombytes(mode='RGB', size=(2000, 2000), data=data)
-        rgb = image.convert('RGB')
+        mode, data = self.engine.image_data_as_rgb(as_bytes=False)
+        rgb = data.convert('RGB')
         red, green, blue = rgb.getpixel((1, 1))
         return "%02x%02x%02x" % (  # pylint: disable=consider-using-f-string
             red,

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -27,7 +27,7 @@ class Filter(BaseFilter):
 
     def get_first_pixel(self):
         mode, data = self.engine.image_data_as_rgb()
-        image = Image.open(io.BytesIO(data))
+        image = Image.frombytes(mode='RGB', size=(2000, 2000), data=data)
         rgb = image.convert('RGB')
         red, green, blue = rgb.getpixel((1, 1))
         return "%02x%02x%02x" % (  # pylint: disable=consider-using-f-string

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -23,6 +23,15 @@ class Filter(BaseFilter):
             blue,
         )
 
+    def get_first_pixel(self):
+        mode, data = self.engine.image_data_as_rgb()
+        red, green, blue = data.getpixel((1, 1))
+        return "%02x%02x%02x" % (  # pylint: disable=consider-using-f-string
+            red,
+            green,
+            blue,
+        )
+
     @filter_method(r"[\w]+", BaseFilter.Boolean)
     async def fill(self, color, fill_transparent=False):
         self.fill_engine = self.engine.__class__(self.context)
@@ -36,6 +45,9 @@ class Filter(BaseFilter):
             if self.context.request.height != 0
             else self.engine.size[1]
         )
+
+        if color == "fpx":
+            color = self.get_first_pixel()
 
         # if the color is 'auto'
         # we will calculate the median color of

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -11,6 +11,8 @@
 from thumbor.ext.filters import _fill
 from thumbor.filters import BaseFilter, filter_method
 from thumbor.filters.blur import apply_blur
+from PIL import Image
+import io
 
 
 class Filter(BaseFilter):
@@ -25,7 +27,9 @@ class Filter(BaseFilter):
 
     def get_first_pixel(self):
         mode, data = self.engine.image_data_as_rgb()
-        red, green, blue = data.getpixel((1, 1))
+        image = Image.open(io.BytesIO(data))
+        rgb = image.convert('RGB')
+        red, green, blue = rgb.getpixel((1, 1))
         return "%02x%02x%02x" % (  # pylint: disable=consider-using-f-string
             red,
             green,

--- a/thumbor/filters/fill.py
+++ b/thumbor/filters/fill.py
@@ -33,6 +33,15 @@ class Filter(BaseFilter):
             blue,
         )
 
+    @classmethod
+    def get_color(cls, self, param):
+        if param == "fpx":
+            return cls.get_first_pixel(self)
+        if param == "auto":
+            return cls.get_median_color(self)
+        else:
+            return param
+
     @filter_method(r"[\w]+", BaseFilter.Boolean)
     async def fill(self, color, fill_transparent=False):
         self.fill_engine = self.engine.__class__(self.context)

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -297,6 +297,9 @@ class BaseHandler(tornado.web.RequestHandler):
                 self.context.request.engine
             ) = JSONEngine(engine, req.image_url, req.meta_callback)
 
+            if req.filters:
+                self.context.request.engine.get_filters()
+
         await self.context.transformer.transform()
         await self.after_transform()
 


### PR DESCRIPTION
- add fpx parameter to fill filter to fill based on corner pixel
- add the requested filters to the meta endpoints with computed parameter values

## Examples

eg. http://localhost:8888/unsafe/meta/fit-in/300x300/filters:fill(fpx):rotate(90):contrast(-40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg
adds the following to the response: 
```
"request_filters": {
        "fill": "060500",
        "rotate": "90",
        "contrast": "-40"
}
```

http://localhost:8888/unsafe/meta/fit-in/300x300/filters:fill(auto):rotate(181):contrast(-40)/https%3A%2F%2Fgithub.com%2Fthumbor%2Fthumbor%2Fraw%2Fmaster%2Fexample.jpg

adds the following to the meta response:
```
"request_filters": {
"fill": "49494a",
"rotate": "0",
"contrast": "-40"
}
```